### PR TITLE
Make .env optional

### DIFF
--- a/main.go
+++ b/main.go
@@ -366,13 +366,10 @@ Compiler: %s %s
 }
 
 func main() {
-	err := godotenv.Load()
-	if err != nil {
-		log.Fatal("Error loading .env file")
-	}
+	godotenv.Load()
 	opts := mainOpts{}
 	psr := flags.NewParser(&opts, flags.HelpFlag)
-	_, err = psr.Parse()
+	_, err := psr.Parse()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
`sacloudns` を実行するディレクトリ直下に `.env` ファイルがないと、 `Error loading .env file` になってしまうため、エラーを無視することで、 `.env` ファイルをオプションにしました。
環境変数と `.env` の両方に値が設定されている場合、環境変数が優先されるようです。
https://pkg.go.dev/github.com/joho/godotenv#Load